### PR TITLE
Typora update to 0.10.6

### DIFF
--- a/automatic/typora/tools/chocolateyInstall.ps1
+++ b/automatic/typora/tools/chocolateyInstall.ps1
@@ -2,12 +2,12 @@
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
-  url            = 'https://typora.io/windows/typora-update-ia32-1213.exe'
-  url64bit       = 'https://typora.io/windows/typora-update-x64-1213.exe'
+  url            = 'https://typora.io/windows/typora-update-ia32-0429.exe'
+  url64bit       = 'https://typora.io/windows/typora-update-x64-0429.exe'
 
-  checksum       = '79635ea487585a88493a05dfcf58bdfe0d25d0f69f7bd434f160726124c5e2f5'
+  checksum       = 'C68A3521D6BDCDD74694FD8AFD495E5AB0D30A404820AE706FFB0364AF3733A3'
   checksumType   = 'sha256'
-  checksum64     = '08fc92c01155eaa8a04d7b03d6cc8d54018fcb0f7b6ab924c5b3dafca1796b69'
+  checksum64     = '3D8BB71095BE42F73DA1D7EF6DD2B7CFFD24129C0CBB4BD3E65A566E577545D3'
   checksumType64 = 'sha256'
 
   validExitCodes = @(0, 3010, 1641)

--- a/automatic/typora/typora.nuspec
+++ b/automatic/typora/typora.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <!-- == PACKAGE SPECIFIC SECTION == -->
     <id>typora</id>
-    <version>0.9.98</version>
+    <version>0.10.6</version>
     <packageSourceUrl>https://github.com/franklinyu/chocolatey-packages/tree/master/automatic/typora</packageSourceUrl>
     <owners>Joseph Benden, Franklin Yu</owners>
     <!-- ============================== -->


### PR DESCRIPTION
The versioning in the filename seems a bit strange at first glance, but installing it updated my installation to 0.10.6.

Please note that the installers on the [homepage](https://typora.io/#windows) have different checksums for reasons unknown. I took the download urls from the [changelog](https://typora.io/windows/dev_release.html).