### PR TITLE
Update jd-gui to v1.6.6

### DIFF
--- a/manual/javadecompiler-gui/javadecompiler-gui.nuspec
+++ b/manual/javadecompiler-gui/javadecompiler-gui.nuspec
@@ -3,14 +3,14 @@
   <metadata>
     <id>javadecompiler-gui</id>
     <title>Java Decompiler GUI</title>
-    <version>1.4.0.20180728</version>
+    <version>1.6.6</version>
     <authors>Emmanuel Dupuy</authors>
     <owners>Surov Vladimir, Franklin Yu</owners>
     <summary>JD (Java Decompiler) is a Decompiler for the Java programming language.</summary>
     <description>JD (Java Decompiler) is a standalone graphical utility that displays Java source codes of “.class” files. You can browse the reconstructed source code with the JD-GUI for instant access to methods and fields.</description>
     <projectUrl>http://jd.benow.ca/</projectUrl>
     <tags>java decompiler gui</tags>
-    <copyright>2008-2015 Emmanuel Dupuy</copyright>
+    <copyright>2008-2019 Emmanuel Dupuy</copyright>
     <licenseUrl>https://opensource.org/licenses/GPL-3.0</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>http://jd.benow.ca/img/Icon_java_64.png</iconUrl>

--- a/manual/javadecompiler-gui/tools/chocolateyInstall.ps1
+++ b/manual/javadecompiler-gui/tools/chocolateyInstall.ps1
@@ -2,9 +2,9 @@
 
 $packageArgs = @{
   packageName   = 'javadecompiler-gui'
-  url           = 'https://github.com/java-decompiler/jd-gui/releases/download/v1.4.0/jd-gui-windows-1.4.0.zip'
-  checksum      = '4cf79cbae4b355cf2b9cd332462491a8'
-  checksumType  = 'md5'
+  url           = 'https://github.com/java-decompiler/jd-gui/releases/download/v1.6.6/jd-gui-windows-1.6.6.zip'
+  checksum      = '79c231399d3d39d14fce7607728336acb47a6e02e9e1c5f2fa16e2450c0c46cb'
+  checksumType  = 'sha256'
   unzipLocation = $toolsDir
 }
 
@@ -19,7 +19,7 @@ else
 $menuPrograms = [Environment]::GetFolderPath($specialFolder)
 $shotrcutArgs = @{
   shortcutFilePath = "$menuPrograms\Java Decompiler.lnk"
-  targetPath       = "$toolsDir\jd-gui-windows-1.4.0\jd-gui.exe"
+  targetPath       = "$toolsDir\jd-gui-windows-1.6.6\jd-gui.exe"
 }
 
 Install-ChocolateyZipPackage @packageArgs


### PR DESCRIPTION
Updated jd-gui to v1.6.6.
Changed checksum type to sha256.
Last version was released more than 2 years ago, so I don't think that an auto updater would be worth writing.